### PR TITLE
Add admin login and product management

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace sem_2_k_2.Controllers
+{
+    public class AccountController : Controller
+    {
+        private const string AdminUser = "admin";
+        private const string AdminPass = "password";
+
+        [HttpGet]
+        public IActionResult Login(string? returnUrl = null)
+        {
+            ViewData["ReturnUrl"] = returnUrl;
+            return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Login(string username, string password, string? returnUrl = null)
+        {
+            if (username == AdminUser && password == AdminPass)
+            {
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Name, username)
+                };
+                var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+                var principal = new ClaimsPrincipal(identity);
+
+                await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+                if (!string.IsNullOrEmpty(returnUrl))
+                    return Redirect(returnUrl);
+                return RedirectToAction("Index", "Home");
+            }
+
+            ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+            ViewData["ReturnUrl"] = returnUrl;
+            return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Logout()
+        {
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/Controllers/ShopController.cs
+++ b/Controllers/ShopController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using sem_2_k_2.Models;
+
+namespace sem_2_k_2.Controllers
+{
+    public class ShopController : Controller
+    {
+        private readonly ProductService _service;
+
+        public ShopController(ProductService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return View(_service.GetAll());
+        }
+
+        [Authorize]
+        [HttpPost]
+        public IActionResult Add(string name, decimal price)
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                _service.Add(new Product { Name = name, Price = price });
+            }
+            return RedirectToAction("Index");
+        }
+
+        [Authorize]
+        [HttpPost]
+        public IActionResult Delete(int id)
+        {
+            _service.Remove(id);
+            return RedirectToAction("Index");
+        }
+    }
+}

--- a/Models/Product.cs
+++ b/Models/Product.cs
@@ -1,0 +1,9 @@
+namespace sem_2_k_2.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+    }
+}

--- a/Models/ProductService.cs
+++ b/Models/ProductService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+
+namespace sem_2_k_2.Models
+{
+    public class ProductService
+    {
+        private readonly ConcurrentDictionary<int, Product> _products = new();
+        private int _nextId = 1;
+
+        public IEnumerable<Product> GetAll() => _products.Values.OrderBy(p => p.Id);
+
+        public void Add(Product product)
+        {
+            product.Id = _nextId++;
+            _products[product.Id] = product;
+        }
+
+        public void Remove(int id)
+        {
+            _products.TryRemove(id, out _);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+
 namespace sem_2_k_2
 {
     public class Program
@@ -8,6 +10,14 @@ namespace sem_2_k_2
 
             // Add services to the container.
             builder.Services.AddControllersWithViews();
+            builder.Services.AddSingleton<Models.ProductService>();
+
+            builder.Services
+                .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                .AddCookie(options =>
+                {
+                    options.LoginPath = "/Account/Login";
+                });
 
             var app = builder.Build();
 
@@ -24,6 +34,7 @@ namespace sem_2_k_2
 
             app.UseRouting();
 
+            app.UseAuthentication();
             app.UseAuthorization();
 
             app.MapControllerRoute(

--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -1,0 +1,21 @@
+@{
+    ViewData["Title"] = "Login";
+    var returnUrl = ViewData["ReturnUrl"] as string;
+}
+<h2>Login</h2>
+<form asp-action="Login" method="post">
+    <input type="hidden" name="returnUrl" value="@returnUrl" />
+    <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input class="form-control" type="text" name="username" />
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input class="form-control" type="password" name="password" />
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+@if (!ViewData.ModelState.IsValid)
+{
+    <div class="text-danger">Invalid login attempt.</div>
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -23,8 +23,30 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Shop" asp-action="Index">Shop</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
+                    </ul>
+                    <ul class="navbar-nav">
+                        @if (User.Identity?.IsAuthenticated == true)
+                        {
+                            <li class="nav-item">
+                                <span class="navbar-text me-2">@User.Identity.Name</span>
+                            </li>
+                            <li class="nav-item">
+                                <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">
+                                    <button type="submit" class="nav-link btn btn-link">Logout</button>
+                                </form>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-controller="Account" asp-action="Login">Login</a>
+                            </li>
+                        }
                     </ul>
                 </div>
             </div>

--- a/Views/Shop/Index.cshtml
+++ b/Views/Shop/Index.cshtml
@@ -1,0 +1,53 @@
+@model IEnumerable<sem_2_k_2.Models.Product>
+@{
+    ViewData["Title"] = "Shop";
+    bool isAdmin = User.Identity?.IsAuthenticated == true && User.Identity.Name == "admin";
+}
+<h2>Shop</h2>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>Name</th>
+            <th>Price</th>
+            @if (isAdmin)
+            {
+                <th>Actions</th>
+            }
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var p in Model)
+        {
+            <tr>
+                <td>@p.Id</td>
+                <td>@p.Name</td>
+                <td>@p.Price</td>
+                @if (isAdmin)
+                {
+                    <td>
+                        <form asp-action="Delete" method="post" style="display:inline">
+                            <input type="hidden" name="id" value="@p.Id" />
+                            <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                        </form>
+                    </td>
+                }
+            </tr>
+        }
+    </tbody>
+</table>
+@if (isAdmin)
+{
+    <h3>Add Product</h3>
+    <form asp-action="Add" method="post">
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input class="form-control" type="text" name="name" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Price</label>
+            <input class="form-control" type="number" step="0.01" name="price" />
+        </div>
+        <button type="submit" class="btn btn-primary">Add</button>
+    </form>
+}


### PR DESCRIPTION
## Summary
- implement cookie authentication with a hard-coded admin account
- add product model and in-memory product service
- create account and shop controllers with corresponding views
- update layout with links for login/logout and shop navigation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e5ee9ff48329b3f0c27810f879c3