### PR TITLE
Add simple auth and admin management

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.FileProviders;
+using System.IO;
+
 namespace sem_2_k_2
 {
     public class Program
@@ -21,6 +24,11 @@ namespace sem_2_k_2
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(Path.Combine(builder.Environment.ContentRootPath, "Views", "Home")),
+                RequestPath = ""
+            });
 
             app.UseRouting();
 

--- a/Views/Home/about.html
+++ b/Views/Home/about.html
@@ -124,7 +124,7 @@
                             <path d="M0 0V3H24V0H0ZM24 21H16V18H24V21ZM24 12H8V9H24V12Z" fill="#fff" />
                         </svg>
                     </button>
-                    <a class="btn btn-main style-small" href="login.html">
+                    <a class="btn btn-main style-small" href="/login.html">
                         <span>
                             <span>
                                 <img src="assets/img/btn-arrow.png" alt="img">

--- a/Views/Home/about.html
+++ b/Views/Home/about.html
@@ -124,7 +124,7 @@
                             <path d="M0 0V3H24V0H0ZM24 21H16V18H24V21ZM24 12H8V9H24V12Z" fill="#fff" />
                         </svg>
                     </button>
-                    <a class="btn btn-main style-small" href="#">
+                    <a class="btn btn-main style-small" href="login.html">
                         <span>
                             <span>
                                 <img src="assets/img/btn-arrow.png" alt="img">

--- a/Views/Home/assets/js/auth.js
+++ b/Views/Home/assets/js/auth.js
@@ -1,0 +1,41 @@
+(function(){
+    const ADMIN_USER = {email: 'admin', password: 'admin', role: 'admin'};
+
+    function loadUsers(){
+        let users = JSON.parse(localStorage.getItem('users') || '[]');
+        if(!users.find(u => u.email === ADMIN_USER.email)){
+            users.push(ADMIN_USER);
+            localStorage.setItem('users', JSON.stringify(users));
+        }
+        return users;
+    }
+    window.auth = {
+        loadUsers,
+        register(email,password){
+            const users = loadUsers();
+            if(users.find(u => u.email === email)) return false;
+            users.push({email,password,role:'пользователь'});
+            localStorage.setItem('users', JSON.stringify(users));
+            return true;
+        },
+        login(email,password){
+            const users = loadUsers();
+            const user = users.find(u => u.email === email && u.password === password);
+            if(user){
+                localStorage.setItem('currentUser', JSON.stringify(user));
+                return user;
+            }
+            return null;
+        },
+        current(){
+            try{ return JSON.parse(localStorage.getItem('currentUser')); }catch(e){return null;}
+        },
+        logout(){
+            localStorage.removeItem('currentUser');
+        },
+        isAdmin(){
+            const u = this.current();
+            return u && u.role === 'admin';
+        }
+    };
+})();

--- a/Views/Home/assets/js/main.js
+++ b/Views/Home/assets/js/main.js
@@ -855,8 +855,18 @@
     $(".btn").on("mouseleave", function() {
         cursor.removeClass("active");
         follower.removeClass("active");
-    });   
+    });
     // CURSOR End
+
+    // redirect connect buttons to login
+    $('a.btn-main').filter(function(){
+        return $(this).find('span:last').text().trim().toLowerCase() === 'connect';
+    }).attr('href','login.html').on('click', function(e){ e.preventDefault(); window.location.href='login.html'; });
+
+    // remove Home tab from menu
+    $('.navbar-nav > li').filter(function(){
+        return $(this).children('a').first().text().trim().toLowerCase() === 'home';
+    }).remove();
 
 
 })(jQuery);

--- a/Views/Home/assets/js/main.js
+++ b/Views/Home/assets/js/main.js
@@ -861,7 +861,7 @@
     // redirect connect buttons to login
     $('a.btn-main').filter(function(){
         return $(this).find('span:last').text().trim().toLowerCase() === 'connect';
-    }).attr('href','login.html').on('click', function(e){ e.preventDefault(); window.location.href='login.html'; });
+    }).attr('href','/login.html').on('click', function(e){ e.preventDefault(); window.location.href='/login.html'; });
 
     // remove Home tab from menu
     $('.navbar-nav > li').filter(function(){

--- a/Views/Home/assets/js/shop.js
+++ b/Views/Home/assets/js/shop.js
@@ -1,0 +1,64 @@
+(function(){
+    function load(){
+        let list = JSON.parse(localStorage.getItem('products')||'[]');
+        if(!list.length){
+            list = [
+                {name:'Baseball Cap',price:'€50.00',image:'assets/img/product/1.png'},
+                {name:'Baseball Cap',price:'€50.00',image:'assets/img/product/2.png'}
+            ];
+            save(list);
+        }
+        return list;
+    }
+    function save(list){
+        localStorage.setItem('products', JSON.stringify(list));
+    }
+    function render(){
+        const list = load();
+        const container = $('#productList').empty();
+        list.forEach((p,i)=>{
+            const item = $('<div class="col-lg-4 col-md-6 product-item"></div>');
+            item.append(`<div class="single-product-inner text-center">
+                <div class="thumb"><img src="${p.image}" alt="img"></div>
+                <div class="details">
+                    <h4 class="title">${p.name}</h4>
+                    <h6 class="amount">${p.price}</h6>
+                    <button class="btn btn-sm btn-danger" data-index="${i}">Удалить</button>
+                </div>
+            </div>`);
+            container.append(item);
+        });
+        updateFilter();
+    }
+    function updateFilter(){
+        const list = load();
+        const select = $('.filter-inner-btn select');
+        if(!select.length) return;
+        select.empty();
+        select.append('<option value="all">Все</option>');
+        [...new Set(list.map(p=>p.name))].forEach(n=>{
+            select.append(`<option value="${n}">${n}</option>`);
+        });
+    }
+
+    $(document).on('submit','#addProductForm',function(e){
+        e.preventDefault();
+        const list = load();
+        list.push({name:$('#productName').val(),price:$('#productPrice').val(),image:$('#productImage').val()});
+        save(list); render(); this.reset();
+    });
+    $(document).on('click','.btn-danger',function(){
+        const idx = $(this).data('index');
+        const list = load();
+        list.splice(idx,1); save(list); render();
+    });
+    $(document).on('change','.filter-inner-btn select',function(){
+        const val = $(this).val();
+        $('.product-item').each(function(){
+            if(val==='all' || $(this).find('.title').text()===val){
+                $(this).show();
+            }else{ $(this).hide(); }
+        });
+    });
+    $(render);
+})();

--- a/Views/Home/assets/js/tournament.js
+++ b/Views/Home/assets/js/tournament.js
@@ -1,0 +1,39 @@
+(function(){
+    function load(){
+        let list = JSON.parse(localStorage.getItem('tournaments')||'null');
+        if(!list){
+            list = [];
+            $('#tournamentList .single-tournament-2').each(function(){
+                const name = $(this).find('h4').text();
+                const image = $(this).find('img.main-img').attr('src');
+                const prize = $(this).find('.color-base').text().trim();
+                list.push({name,image,prize});
+            });
+            save(list);
+        }
+        return list;
+    }
+    function save(list){ localStorage.setItem('tournaments', JSON.stringify(list)); }
+    function render(){
+        const list = load();
+        const c = $('#tournamentList').empty();
+        list.forEach((t,i)=>{
+            c.append(`<div class="col-lg-6 fade-slide bottom"><div class="single-tournament-2"><img class="bg-img" src="assets/img/tournament/bg-3.png" alt="img"><div class="content-area"><div class="top-area d-flex align-items-center align-self-center"><img class="me-3 main-img" src="${t.image}" alt="img"><div class="details"><h6>Action</h6><h4 class="mb-0">${t.name}</h4></div></div><span class="line-shadow"></span><div class="bottom-area"><div class="row"><div class="col-4"><span>PRIZE</span><br><span class="color-base">${t.prize}</span></div><div class="col-4"></div><div class="col-4 text-end">${auth.isAdmin()?`<button class='btn btn-danger btn-sm' data-index='${i}'>Удалить</button>`:''}</div></div></div></div></div>`);
+        });
+    }
+    $(document).on('submit','#addTournamentForm',function(e){
+        e.preventDefault();
+        const list = load();
+        list.push({name:$('#tourName').val(), prize:$('#tourPrize').val(), image:$('#tourImage').val()});
+        save(list); render(); this.reset();
+    });
+    $(document).on('click','#tournamentList .btn-danger',function(){
+        const i=$(this).data('index');
+        const list = load();
+        list.splice(i,1); save(list); render();
+    });
+    $(function(){
+        if(auth.isAdmin()) $('#addTournamentForm').show();
+        render();
+    });
+})();

--- a/Views/Home/login.html
+++ b/Views/Home/login.html
@@ -189,9 +189,19 @@
             <div class="row">
                 <div class="col-lg-6 pe-xl-5">
                     <div class="pe-xl-5 pe-lg-4">
-                        <div class="section-title">
-                            <h6 class="subtitle tt-uppercase">Authorization</h6>
-                            <h2 class="title">Login</h2>
+                        <div id="loginTitleBlock" class="section-title">
+                            <div class="row">
+                                <h6 class="subtitle tt-uppercase">Welcome back</h6>
+                                <h2 class="title">Log in</h2>
+                                <p class="mb-0 mt-3">Нет аккаунта? <a id="showRegister" class="color-base" href="#">Регистрация</a></p>
+                            </div>
+                        </div>
+                        <div id="registerTitleBlock" class="section-title" style="display:none;">
+                            <div class="row">
+                                <h6 class="subtitle tt-uppercase">Start for free</h6>
+                                <h2 class="title">Create <span>account</span></h2>
+                                <p class="mb-0 mt-3">Уже есть аккаунт? <a id="showLogin" class="color-base" href="#">Войти</a></p>
+                            </div>
                         </div>
                         <form id="loginForm" class="login-form-inner">
                             <div class="single-input-inner style-border">
@@ -203,7 +213,6 @@
                                 <span><img src="assets/img/icon/18.png" alt="img"></span>
                             </div>
                             <button type="submit" class="btn btn-base tt-uppercase w-100">Log in</button>
-                            <p class="mt-3">Нет аккаунта? <a id="showRegister" class="color-base" href="#">Регистрация</a></p>
                         </form>
 
                         <form id="registerForm" class="login-form-inner" style="display:none;">
@@ -216,7 +225,6 @@
                                 <span><img src="assets/img/icon/18.png" alt="img"></span>
                             </div>
                             <button type="submit" class="btn btn-base tt-uppercase w-100">Register</button>
-                            <p class="mt-3">Есть аккаунт? <a id="showLogin" class="color-base" href="#">Войти</a></p>
                         </form>
                     </div>
                 </div>
@@ -354,8 +362,20 @@
     <!-- main js  -->
     <script src="assets/js/main.js"></script>
     <script>
-        document.getElementById('showRegister').onclick = function(e){e.preventDefault();document.getElementById('loginForm').style.display='none';document.getElementById('registerForm').style.display='block';};
-        document.getElementById('showLogin').onclick = function(e){e.preventDefault();document.getElementById('registerForm').style.display='none';document.getElementById('loginForm').style.display='block';};
+        document.getElementById('showRegister').onclick = function(e){
+            e.preventDefault();
+            document.getElementById('loginForm').style.display = 'none';
+            document.getElementById('registerForm').style.display = 'block';
+            document.getElementById('loginTitleBlock').style.display = 'none';
+            document.getElementById('registerTitleBlock').style.display = 'block';
+        };
+        document.getElementById('showLogin').onclick = function(e){
+            e.preventDefault();
+            document.getElementById('registerForm').style.display = 'none';
+            document.getElementById('loginForm').style.display = 'block';
+            document.getElementById('registerTitleBlock').style.display = 'none';
+            document.getElementById('loginTitleBlock').style.display = 'block';
+        };
         document.getElementById('registerForm').onsubmit = function(e){
             e.preventDefault();
             if(auth.register(document.getElementById('regEmail').value, document.getElementById('regPassword').value)){

--- a/Views/Home/login.html
+++ b/Views/Home/login.html
@@ -190,25 +190,33 @@
                 <div class="col-lg-6 pe-xl-5">
                     <div class="pe-xl-5 pe-lg-4">
                         <div class="section-title">
-                            <div class="row">
-                                <h6 class="subtitle tt-uppercase">Start for free</h6>
-                                <h2 class="title">Create <span>account</span></h2>
-                                <p class="mb-0 mt-3">Already a Member? <a class="color-base" href="#">Log in</a></p>
-                            </div>
+                            <h6 class="subtitle tt-uppercase">Authorization</h6>
+                            <h2 class="title">Login</h2>
                         </div>
-                        <form class="login-form-inner">
+                        <form id="loginForm" class="login-form-inner">
                             <div class="single-input-inner style-border">
-                                <input type="text" placeholder="Your Email">
+                                <input id="loginEmail" type="text" placeholder="Email">
                                 <span><img src="assets/img/icon/17.png" alt="img"></span>
                             </div>
                             <div class="single-input-inner style-border">
-                                <input type="password" placeholder="Password">
+                                <input id="loginPassword" type="password" placeholder="Password">
                                 <span><img src="assets/img/icon/18.png" alt="img"></span>
                             </div>
-                            <a class="btn btn-base tt-uppercase w-100" href="#">Log in</a>
-                            <div class="text-md-end mt-4 tt-uppercase">
-                                <button class="bg-transparent border-0 text-white" type="submit">forget your password</button>
+                            <button type="submit" class="btn btn-base tt-uppercase w-100">Log in</button>
+                            <p class="mt-3">Нет аккаунта? <a id="showRegister" class="color-base" href="#">Регистрация</a></p>
+                        </form>
+
+                        <form id="registerForm" class="login-form-inner" style="display:none;">
+                            <div class="single-input-inner style-border">
+                                <input id="regEmail" type="text" placeholder="Email">
+                                <span><img src="assets/img/icon/17.png" alt="img"></span>
                             </div>
+                            <div class="single-input-inner style-border">
+                                <input id="regPassword" type="password" placeholder="Password">
+                                <span><img src="assets/img/icon/18.png" alt="img"></span>
+                            </div>
+                            <button type="submit" class="btn btn-base tt-uppercase w-100">Register</button>
+                            <p class="mt-3">Есть аккаунт? <a id="showLogin" class="color-base" href="#">Войти</a></p>
                         </form>
                     </div>
                 </div>
@@ -342,8 +350,31 @@
     <script src="assets/js/gsap.min.js"></script>
     <script src="assets/js/lenis.min.js"></script>
     
+    <script src="assets/js/auth.js"></script>
     <!-- main js  -->
     <script src="assets/js/main.js"></script>
+    <script>
+        document.getElementById('showRegister').onclick = function(e){e.preventDefault();document.getElementById('loginForm').style.display='none';document.getElementById('registerForm').style.display='block';};
+        document.getElementById('showLogin').onclick = function(e){e.preventDefault();document.getElementById('registerForm').style.display='none';document.getElementById('loginForm').style.display='block';};
+        document.getElementById('registerForm').onsubmit = function(e){
+            e.preventDefault();
+            if(auth.register(document.getElementById('regEmail').value, document.getElementById('regPassword').value)){
+                alert('Регистрация успешна');
+                document.getElementById('showLogin').click();
+            }else{
+                alert('Пользователь уже существует');
+            }
+        };
+        document.getElementById('loginForm').onsubmit = function(e){
+            e.preventDefault();
+            if(auth.login(document.getElementById('loginEmail').value, document.getElementById('loginPassword').value)){
+                alert('Успешный вход');
+                window.location.href='index.html';
+            }else{
+                alert('Неверные данные');
+            }
+        };
+    </script>
     
 </body>
 

--- a/Views/Home/shop.html
+++ b/Views/Home/shop.html
@@ -286,171 +286,24 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row">
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/1.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/2.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div> 
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/3.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/4.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/1.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/2.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div> 
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/3.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/4.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <div class="single-product-inner text-center">
-                                <div class="thumb">
-                                    <img src="assets/img/product/2.png" alt="img">
-                                </div>
-                                <div class="details">
-                                    <h4 class="title"><a href="shop-details.html">Baseball Cap</a></h4>
-                                    <div class="ratting">
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                        <i class="fa fa-star"></i>
-                                    </div>
-                                    <h6 class="amount">€50.00</h6>
-                                </div>
-                            </div>
-                        </div> 
-                    </div>
                 </div>
+                    <div id="productControls" class="mb-5">
+                        <form id="addProductForm" class="row g-3">
+                            <div class="col-md-4">
+                                <input type="text" id="productName" class="form-control" placeholder="Название" required>
+                            </div>
+                            <div class="col-md-3">
+                                <input type="text" id="productPrice" class="form-control" placeholder="Цена" required>
+                            </div>
+                            <div class="col-md-4">
+                                <input type="text" id="productImage" class="form-control" placeholder="Ссылка на изображение" required>
+                            </div>
+                            <div class="col-md-1">
+                                <button type="submit" class="btn btn-base">Добавить</button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="row" id="productList"></div>
             </div>
         </div>
     </div>
@@ -560,6 +413,8 @@
     <script src="assets/js/gsap.min.js"></script>
     <script src="assets/js/lenis.min.js"></script>
     
+    <script src="assets/js/auth.js"></script>
+    <script src="assets/js/shop.js"></script>
     <!-- main js  -->
     <script src="assets/js/main.js"></script>
     

--- a/Views/Home/tournament.html
+++ b/Views/Home/tournament.html
@@ -173,6 +173,12 @@
     <!-- page title start -->
     <div class="breadcrumb-area bg-cover" style="background-image: url('assets/img/bg/4.png');">
         <div class="container">
+            <form id="addTournamentForm" style="display:none" class="row g-3 mb-4">
+                <div class="col-md-4"><input id="tourName" type="text" class="form-control" placeholder="Название" required></div>
+                <div class="col-md-3"><input id="tourPrize" type="text" class="form-control" placeholder="Приз" required></div>
+                <div class="col-md-4"><input id="tourImage" type="text" class="form-control" placeholder="Ссылка на изображение" required></div>
+                <div class="col-md-1"><button type="submit" class="btn btn-base">Добавить</button></div>
+            </form>
             <div class="breadcrumb-inner">
                 <h2 class="page-title">Tournament</h2>
                 <ul class="page-list">
@@ -187,7 +193,13 @@
     <!-- tournament area start -->
     <div class="tournament-area pd-top-120 pd-bottom-100">
         <div class="container">
-            <div class="row">
+            <form id="addTournamentForm" style="display:none" class="row g-3 mb-4">
+                <div class="col-md-4"><input id="tourName" type="text" class="form-control" placeholder="Название" required></div>
+                <div class="col-md-3"><input id="tourPrize" type="text" class="form-control" placeholder="Приз" required></div>
+                <div class="col-md-4"><input id="tourImage" type="text" class="form-control" placeholder="Ссылка на изображение" required></div>
+                <div class="col-md-1"><button type="submit" class="btn btn-base">Добавить</button></div>
+            </form>
+            <div id="tournamentList" class="row">
                 <div class="col-lg-6 fade-slide bottom" data-delay="0.2">
                     <div class="single-tournament-2">
                         <img class="bg-img" src="assets/img/tournament/bg-3.png" alt="img">
@@ -390,6 +402,12 @@
     <!-- team area start -->
     <div class="team-area pd-top-120">
         <div class="container">
+            <form id="addTournamentForm" style="display:none" class="row g-3 mb-4">
+                <div class="col-md-4"><input id="tourName" type="text" class="form-control" placeholder="Название" required></div>
+                <div class="col-md-3"><input id="tourPrize" type="text" class="form-control" placeholder="Приз" required></div>
+                <div class="col-md-4"><input id="tourImage" type="text" class="form-control" placeholder="Ссылка на изображение" required></div>
+                <div class="col-md-1"><button type="submit" class="btn btn-base">Добавить</button></div>
+            </form>
             <div class="section-title text-center">
                 <h6 class="sub-title split_chars">Our team</h6>
                 <h2 class="title move-line-3d">meet our member</h2>
@@ -468,6 +486,12 @@
     <!-- footer area start -->
     <footer class="footer-area footer-area-1 pd-top-110" style="background-image: url('assets/img/footer/bg.png');">
         <div class="container">
+            <form id="addTournamentForm" style="display:none" class="row g-3 mb-4">
+                <div class="col-md-4"><input id="tourName" type="text" class="form-control" placeholder="Название" required></div>
+                <div class="col-md-3"><input id="tourPrize" type="text" class="form-control" placeholder="Приз" required></div>
+                <div class="col-md-4"><input id="tourImage" type="text" class="form-control" placeholder="Ссылка на изображение" required></div>
+                <div class="col-md-1"><button type="submit" class="btn btn-base">Добавить</button></div>
+            </form>
             <div class="row">
                 <div class="col-lg-3 col-md-6">
                     <div class="widget widget_about">
@@ -534,6 +558,12 @@
         </div>
         <div class="footer-bottom">
             <div class="container">
+            <form id="addTournamentForm" style="display:none" class="row g-3 mb-4">
+                <div class="col-md-4"><input id="tourName" type="text" class="form-control" placeholder="Название" required></div>
+                <div class="col-md-3"><input id="tourPrize" type="text" class="form-control" placeholder="Приз" required></div>
+                <div class="col-md-4"><input id="tourImage" type="text" class="form-control" placeholder="Ссылка на изображение" required></div>
+                <div class="col-md-1"><button type="submit" class="btn btn-base">Добавить</button></div>
+            </form>
                 <div class="row">
                     <div class="col-lg-6 align-self-center">
                         <p>© 2024 By dyat, All Rights Reserved</p>
@@ -568,6 +598,8 @@
     <script src="assets/js/gsap.min.js"></script>
     <script src="assets/js/lenis.min.js"></script>
     
+    <script src="assets/js/auth.js"></script>
+    <script src="assets/js/tournament.js"></script>
     <!-- main js  -->
     <script src="assets/js/main.js"></script>
     


### PR DESCRIPTION
## Summary
- add auth helper for storing users
- enable login and registration with role "пользователь"
- implement product management and filtering on shop page
- allow admin to manage tournaments
- adjust main script to remove Home tab and route Connect to login

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b1d9ea4c483298edb6a3aec77c27a